### PR TITLE
FS-479: Colour mention based on value

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
 # forsite-ckeditor-mentions
 
 This is an extension on the original [Mention plugin for CKEditor](https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-mention) specifically for use in [ForSite](https://github.com/estimateone/forsite-core)
+
+# Usage
+
+## Colourised mentions
+
+Mentions in the document will be colourised depending on whether there is a value associated with the selected mention.
+You can provide a boolean in the feed for the mentions plugin to control whether there is a value.
+e.g.
+```javascript
+mention: {
+        feeds: [
+            {
+                marker: '@',
+                feed: [
+                    { id: '@swarley', userId: '1', name: 'Barney Stinson', isPopulated: true},
+                    { id: '@lilypad', userId: '2', name: 'Lily Aldrin', isPopulated: false},
+                    { id: '@marshmallow', userId: '3', name: 'Marshall Eriksen', isPopulated: true},
+                    { id: '@rsparkles', userId: '4', name: 'Robin Scherbatsky', isPopulated: false},
+                    { id: '@tdog', userId: '5', name: 'Ted Mosby', isPopulated: true},
+                ],
+                minimumCharacters: 1
+            }
+        ]
+    }
+```

--- a/theme/mention.css
+++ b/theme/mention.css
@@ -3,7 +3,14 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-.mention {
-    background: rgba(153, 0, 48, 0.1);
-    color: #990030;
+.unpopulated {
+    color: black;
+    background: var(--west-200);
+    text-decoration: underline var(--west-400);
+}
+
+.populated {
+    color: black;
+    background: var(--iron-100);
+    text-decoration: underline var(--iron-300);
 }

--- a/theme/variables.css
+++ b/theme/variables.css
@@ -1,0 +1,6 @@
+:root {
+    --iron-100: #E6E6E6;
+    --iron-300: #B2B2B2;
+    --west-200: #FFD0A2;
+    --west-400: #FFA246;
+}


### PR DESCRIPTION
## What

[FS-479](https://estimate1.atlassian.net/browse/FS-479)

This PR adds functionality to our CKEditor mentions plugin to allow for colourising mentions based on whether there is a value associated with the selected mention

## Changes

- Adapted plugin code to allow for highlighting based on the isPopulated value of an item in the mention feed
- Added some usage docs to the README
- Added some colours from ForSite design system as  CSS variables

## Screenshots

![Screen Shot 2021-10-05 at 10 19 22 am](https://user-images.githubusercontent.com/20939486/135937167-6764ee6e-073d-444d-90b4-68d004aff035.png)
