### PR TITLE
Ensure feedItem is populated before trying to access it's fields

### DIFF
--- a/src/mentionediting.js
+++ b/src/mentionediting.js
@@ -150,7 +150,7 @@ const createViewMentionElement = (feed) => ( mention, { writer } ) => {
 	const feedItem = feed.find(({ id }) => id === mention._text);
 	const isPopulatedIsUndefined = mention.isPopulated === "undefined" || mention.isPopulated === undefined;
 	const mentionIsPopulated = mention.isPopulated === "true" || mention.isPopulated === true;
-	const isPopulated = (!isPopulatedIsUndefined && mentionIsPopulated) || feedItem.isPopulated;
+	const isPopulated = (!isPopulatedIsUndefined && mentionIsPopulated) || (feedItem && feedItem.isPopulated);
 
 	const statusClass = isPopulated ? 'populated' : 'unpopulated';
 


### PR DESCRIPTION
## What

We ran into a bug where if a mention exists in a document that doesn't exist in the feed (the mentions that CKEditor knows about and renders in the drop-down menu) CKEditor would crash and display a read-only state.